### PR TITLE
Allow plugins to provide boolean values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased][]
 
+### Fixed
+
+- Support plugins that have boolean values for settings.
+
 ## [1.0.2][] - 2017-11-28
 
 ### Fixed

--- a/src/lib/load-remark-preset.js
+++ b/src/lib/load-remark-preset.js
@@ -26,10 +26,12 @@ function parseOptions(options) {
     let value = options[key];
 
     // Replace if value matches ${...}
-    const match = value.match(/\${(.*)}$/);
-    if (match) {
-      const variableName = match[1];
-      value = getEnvVariable(variableName);
+    if (typeof value.match === 'function') {
+      const match = value.match(/\${(.*)}$/);
+      if (match) {
+        const variableName = match[1];
+        value = getEnvVariable(variableName);
+      }
     }
 
     parsedOptions[key] = value;

--- a/test/lib/load-remark-preset.test.js
+++ b/test/lib/load-remark-preset.test.js
@@ -61,4 +61,29 @@ describe('load-remark-preset', () => {
     expect(plugin[1].gitlabApiToken).toBe('abc123');
     expect(plugin[1].directory).toBe('blah');
   });
+
+  it('load config with values', () => {
+    const config = {
+      plugins: [
+        [
+          'remark-gitlab-artifact',
+          {
+            gitlabApiToken: true,
+            directory: 'blah',
+          },
+        ],
+      ],
+    };
+
+    const preset = loadRemarkPreset(config);
+    expect(preset.plugins).toBeInstanceOf(Array);
+    expect(preset.plugins).toHaveLength(1);
+
+    const plugin = preset.plugins[0];
+    expect(plugin).toBeInstanceOf(Array);
+    expect(plugin).toHaveLength(2);
+    expect(typeof plugin[0]).toBe('function');
+    expect(plugin[1].gitlabApiToken).toBe(true);
+    expect(plugin[1].directory).toBe('blah');
+  });
 });


### PR DESCRIPTION
This allows plugins like [`remark-mermaid`](https://github.com/temando/remark-mermaid) to work with Kunst.